### PR TITLE
Add PDF page rendering tool with basic hardening and CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Base directory for PDFs
+PDF_BASE_DIR=/absolute/path/to/pdfs
+# Optional directory for rendered images
+PDF_IMAGE_DIR=/tmp/pdf-images
+# Optional maximum DPI for rendering
+PDF_MAX_DPI=600

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: ci
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: System deps
+        run: sudo apt-get update && sudo apt-get install -y tesseract-ocr
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev,ocr]
+      - name: Test
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ cd mcp-pdf-reader-server
 
 3. **Initialize and install with UV:**
 ```bash
-# Copy the files (pdf_reader_server.py and pyproject.toml)
-# Then install dependencies
+# Install dependencies
 uv sync
 ```
 
@@ -90,17 +89,18 @@ pip install fastmcp PyMuPDF pytesseract Pillow
 
 ### Running the Server
 
-With UV:
+With the console script:
 ```bash
-uv run python pdf_reader_server.py
+mcp-pdf-reader
 ```
 
-Or if you have the environment activated:
+Or using Python directly:
 ```bash
-python pdf_reader_server.py
+python -m mcp_pdf_reader.server
 ```
 
-The server will start and listen for MCP requests on stdin/stdout.
+The server will start and listen for MCP requests on stdin/stdout. Set `PDF_BASE_DIR`
+to the directory containing PDFs before running.
 
 ### Available Tools
 
@@ -119,7 +119,28 @@ Extract text content from PDF pages.
 }
 ```
 
-#### 2. `extract_pdf_images`
+#### 2. `render_pdf_page`
+Render a single PDF page to an image file.
+
+**Parameters:**
+- `file_path` (string, required)
+- `page` (int, required, 1-based)
+- `dpi` (int, optional, default 200)
+- `fmt` (string, optional, `png` or `jpeg`)
+- `output_dir` (string, optional)
+- `return_base64` (boolean, default `false`)
+
+**Example:**
+```json
+{
+  "file_path": "/path/to/document.pdf",
+  "page": 1,
+  "dpi": 300,
+  "fmt": "png"
+}
+```
+
+#### 3. `extract_pdf_images`
 Extract all images from a PDF file.
 
 **Parameters:**
@@ -136,7 +157,7 @@ Extract all images from a PDF file.
 }
 ```
 
-#### 3. `read_pdf_with_ocr`
+#### 4. `read_pdf_with_ocr`
 Extract text from both regular text and images using OCR.
 
 **Parameters:**
@@ -160,13 +181,13 @@ Extract text from both regular text and images using OCR.
 - `spa` - Spanish
 - `eng+fra` - Multiple languages
 
-#### 4. `get_pdf_info`
+#### 5. `get_pdf_info`
 Get comprehensive metadata and statistics about a PDF.
 
 **Parameters:**
 - `file_path` (string, required): Path to the PDF file
 
-#### 5. `analyze_pdf_structure`
+#### 6. `analyze_pdf_structure`
 Analyze the structure and content distribution of a PDF.
 
 **Parameters:**
@@ -181,36 +202,8 @@ Add this to your `claude_desktop_config.json`:
 {
   "mcpServers": {
     "pdf-reader": {
-      "command": "uv",
-      "args": ["run", "python", "/path/to/your/pdf_reader_server.py"],
-      "cwd": "/path/to/your/mcp-pdf-reader-server"
-    }
-  }
-}
-```
-
-### With Virtual Environment
-```json
-{
-  "mcpServers": {
-    "pdf-reader": {
-      "command": "/path/to/your/.venv/bin/python",
-      "args": ["/path/to/your/pdf_reader_server.py"]
-    }
-  }
-}
-```
-
-### System Python
-```json
-{
-  "mcpServers": {
-    "pdf-reader": {
-      "command": "python",
-      "args": ["/path/to/your/pdf_reader_server.py"],
-      "env": {
-        "PYTHONPATH": "/path/to/your/.venv/lib/python3.x/site-packages"
-      }
+      "command": "mcp-pdf-reader",
+      "args": []
     }
   }
 }
@@ -317,14 +310,14 @@ Add this to your `claude_desktop_config.json`:
 
 ### Debug Mode
 
-Run with debug logging using UV:
+Run with debug logging using the console script:
 ```bash
-PYTHONUNBUFFERED=1 uv run python pdf_reader_server.py
+PYTHONUNBUFFERED=1 mcp-pdf-reader
 ```
 
 Or with regular Python:
 ```bash
-PYTHONUNBUFFERED=1 python pdf_reader_server.py
+PYTHONUNBUFFERED=1 python -m mcp_pdf_reader.server
 ```
 
 ### Testing OCR

--- a/examples/claude_desktop_config.json
+++ b/examples/claude_desktop_config.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "pdf-reader": {
+      "command": "mcp-pdf-reader",
+      "args": []
+    }
+  }
+}

--- a/main.py
+++ b/main.py
@@ -1,6 +1,4 @@
-def main():
-    print("Hello from mcp-pdf-reader!")
-
+from mcp_pdf_reader.server import run
 
 if __name__ == "__main__":
-    main()
+    run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "mcp-pdf-reader-server"
+name = "mcp-pdf-reader"
 version = "0.1.0"
 description = "MCP server for reading PDFs with text extraction, image extraction, and OCR"
 authors = [
@@ -7,7 +7,7 @@ authors = [
 ]
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 keywords = ["mcp", "pdf", "ocr", "text-extraction", "fastmcp"]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -36,10 +36,7 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.0.0",
 ]
-enhanced = [
-    "opencv-python>=4.8.0",
-    "numpy>=1.24.0",
-]
+ocr = ["pytesseract>=0.3.10"]
 
 [project.urls]
 Homepage = "https://github.com/labeveryday/mcp_pdf_reader"
@@ -47,14 +44,14 @@ Repository = "https://github.com/labeveryday/mcp_pdf_reader"
 Issues = "https://github.com/labeveryday/mcp_pdf_reader"
 
 [project.scripts]
-mcp-pdf-reader = "pdf_reader_server:main"
+mcp-pdf-reader = "mcp_pdf_reader.server:run"
 
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["pdf_reader_server.py"]
+packages = ["src/mcp_pdf_reader"]
 
 [tool.black]
 target-version = ['py39']

--- a/src/mcp_pdf_reader/__init__.py
+++ b/src/mcp_pdf_reader/__init__.py
@@ -1,0 +1,1 @@
+"""PDF reader MCP server package."""

--- a/src/mcp_pdf_reader/app.py
+++ b/src/mcp_pdf_reader/app.py
@@ -1,0 +1,3 @@
+from fastmcp import FastMCP
+
+mcp = FastMCP("pdf-reader")

--- a/src/mcp_pdf_reader/security.py
+++ b/src/mcp_pdf_reader/security.py
@@ -1,0 +1,24 @@
+import os
+from pathlib import Path
+
+
+def get_allowed_base() -> Path:
+    env = os.getenv("PDF_BASE_DIR")
+    if not env:
+        raise RuntimeError("PDF_BASE_DIR must be set to an allow-listed directory")
+    return Path(env).resolve()
+
+
+def get_output_dir(overridden: str | None) -> Path:
+    env = overridden or os.getenv("PDF_IMAGE_DIR")
+    return Path(env).resolve() if env else Path(os.getenv("TMPDIR") or "/tmp")
+
+
+def resolve_and_check(path: str, base: Path) -> Path:
+    p = (base / path).resolve() if not os.path.isabs(path) else Path(path).resolve()
+    base_resolved = base.resolve()
+    if not str(p).startswith(str(base_resolved) + os.sep) and p != base_resolved:
+        raise ValueError("file_path outside allowed base directory")
+    if not p.exists():
+        raise FileNotFoundError(f"not found: {p}")
+    return p

--- a/src/mcp_pdf_reader/server.py
+++ b/src/mcp_pdf_reader/server.py
@@ -1,0 +1,10 @@
+from .app import mcp
+
+# Import tools so they register via decorators
+from . import tools_text  # noqa: F401
+from .tools_render import render_pdf_page  # noqa: F401
+
+
+def run() -> None:
+    """Run the MCP server over stdio."""
+    mcp.run_stdio()

--- a/src/mcp_pdf_reader/tools_render.py
+++ b/src/mcp_pdf_reader/tools_render.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+from pathlib import Path
+
+import fitz  # PyMuPDF
+
+from .app import mcp
+from .security import get_allowed_base, get_output_dir, resolve_and_check
+
+MAX_DPI = int(os.getenv("PDF_MAX_DPI", "600"))
+
+
+@mcp.tool()
+def render_pdf_page(
+    file_path: str,
+    page: int,
+    dpi: int = 200,
+    fmt: str = "png",
+    output_dir: str | None = None,
+    return_base64: bool = False,
+):
+    """Render a single PDF page to an image."""
+    if fmt.lower() == "jpg":
+        fmt = "jpeg"
+    if fmt.lower() not in ("png", "jpeg"):
+        raise ValueError("fmt must be 'png' or 'jpeg'")
+    if dpi < 72 or dpi > MAX_DPI:
+        raise ValueError(f"dpi must be between 72 and {MAX_DPI}")
+
+    base_dir = get_allowed_base()
+    pdf_path = resolve_and_check(file_path, base_dir)
+
+    doc = fitz.open(pdf_path)
+    if page < 1 or page > doc.page_count:
+        raise ValueError(f"page must be in 1..{doc.page_count}")
+
+    p = doc.load_page(page - 1)
+    scale = dpi / 72.0
+    pix = p.get_pixmap(matrix=fitz.Matrix(scale, scale), alpha=False)
+
+    out_dir = get_output_dir(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stem = pdf_path.stem
+    suffix = "jpg" if fmt == "jpeg" else "png"
+    out_file = out_dir / f"{stem}-p{page}-{dpi}dpi.{suffix}"
+    pix.save(str(out_file))
+
+    data = out_file.read_bytes()
+    sha256 = hashlib.sha256(data).hexdigest()
+
+    result = {
+        "path": str(out_file),
+        "page": page,
+        "dpi": dpi,
+        "format": fmt,
+        "width": pix.width,
+        "height": pix.height,
+        "sha256": sha256,
+    }
+    if return_base64:
+        result["data_base64"] = base64.b64encode(data).decode("ascii")
+    return result

--- a/src/mcp_pdf_reader/tools_text.py
+++ b/src/mcp_pdf_reader/tools_text.py
@@ -1,23 +1,18 @@
-#!/usr/bin/env python3
-
-import json
 import logging
-import os
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from io import BytesIO
 
 import fitz  # PyMuPDF
 import pytesseract
-from fastmcp import FastMCP
+
+from .app import mcp
 from PIL import Image
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("pdf-reader-server")
-
-# Initialize FastMCP server
-mcp = FastMCP("PDF Reader Server")
 
 def validate_file_path(file_path: str) -> Path:
     """Validate that the file path exists and is a PDF"""
@@ -489,5 +484,3 @@ def analyze_pdf_structure(file_path: str) -> Dict[str, Any]:
             "file_path": file_path
         }
 
-if __name__ == "__main__":
-    mcp.run()

--- a/tests/test_render_pdf_page.py
+++ b/tests/test_render_pdf_page.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import fitz
+import pytest
+
+from mcp_pdf_reader.tools_render import render_pdf_page
+
+
+def make_pdf(tmp_path: Path) -> Path:
+    pdf = tmp_path / "sample.pdf"
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), "Hello PDF")
+    doc.save(pdf)
+    return pdf
+
+
+def test_render_png(tmp_path, monkeypatch):
+    base = tmp_path / "docs"
+    base.mkdir()
+    pdf = make_pdf(base)
+    monkeypatch.setenv("PDF_BASE_DIR", str(base))
+    out = render_pdf_page.fn(str(pdf), page=1, dpi=200, fmt="png", return_base64=False)
+    assert out["path"].endswith(".png")
+    assert out["width"] > 0 and out["height"] > 0
+    assert len(out["sha256"]) == 64
+
+
+def test_out_of_range(tmp_path, monkeypatch):
+    base = tmp_path / "docs"
+    base.mkdir()
+    pdf = make_pdf(base)
+    monkeypatch.setenv("PDF_BASE_DIR", str(base))
+    with pytest.raises(ValueError):
+        render_pdf_page.fn(str(pdf), page=2)
+
+
+def test_directory_escape(tmp_path, monkeypatch):
+    base = tmp_path / "docs"
+    base.mkdir()
+    other = tmp_path / "other"
+    other.mkdir()
+    pdf = make_pdf(other)
+    monkeypatch.setenv("PDF_BASE_DIR", str(base))
+    with pytest.raises((ValueError, FileNotFoundError)):
+        render_pdf_page.fn(str(pdf), page=1)


### PR DESCRIPTION
## Summary
- restructure server into package with console entrypoint
- add secure `render_pdf_page` tool to export PDF pages as images
- document new tool, environment variables, and update run instructions
- include tests and GitHub Actions CI

## Testing
- `PYENV_VERSION=3.12.10 pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68ac87ae23e8832182c9a90fbd374d7f